### PR TITLE
Change HttpExceptionHandler to handle a error response model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ repositories {
 }
 
 dependencies {
-    compile     group: 'org.apache.camel',                               name: 'camel-core',                         version: '2.16.1'
-    compile     group: 'org.apache.httpcomponents',               name: 'httpclient',                         version: '4.3.3'
-    compile     group: 'org.slf4j',                                              name: 'slf4j-api',                          version: '1.7.7'
+    compile     group: 'org.apache.camel',          name: 'camel-core',                         version: '2.16.1'
+    compile     group: 'org.apache.httpcomponents', name: 'httpclient',                         version: '4.3.3'
+    compile     group: 'org.slf4j',                 name: 'slf4j-api',                          version: '1.7.7'
     compile     group: 'com.fasterxml.jackson.core',                 name: 'jackson-databind',             version: '2.7.3'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,11 @@ repositories {
 }
 
 dependencies {
-    compile     group: 'org.apache.camel',          name: 'camel-core',                         version: '2.16.1'
-    compile     group: 'org.apache.httpcomponents', name: 'httpclient',                         version: '4.3.3'
-    compile     group: 'org.slf4j',                 name: 'slf4j-api',                          version: '1.7.7'
+    compile     group: 'org.apache.camel',                               name: 'camel-core',                         version: '2.16.1'
+    compile     group: 'org.apache.httpcomponents',               name: 'httpclient',                         version: '4.3.3'
+    compile     group: 'org.slf4j',                                              name: 'slf4j-api',                          version: '1.7.7'
+    compile     group: 'com.fasterxml.jackson.core',                 name: 'jackson-databind',             version: '2.7.3'
+
 }
 
 release {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile     group: 'org.apache.camel',          name: 'camel-core',                         version: '2.16.1'
     compile     group: 'org.apache.httpcomponents', name: 'httpclient',                         version: '4.3.3'
     compile     group: 'org.slf4j',                 name: 'slf4j-api',                          version: '1.7.7'
-    compile     group: 'com.fasterxml.jackson.core', name: 'jackson-databind',             version: '2.7.3'
+    compile     group: 'com.fasterxml.jackson.core',name: 'jackson-databind',             version: '2.7.3'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile     group: 'org.apache.camel',          name: 'camel-core',                         version: '2.16.1'
     compile     group: 'org.apache.httpcomponents', name: 'httpclient',                         version: '4.3.3'
     compile     group: 'org.slf4j',                 name: 'slf4j-api',                          version: '1.7.7'
-    compile     group: 'com.fasterxml.jackson.core',                 name: 'jackson-databind',             version: '2.7.3'
+    compile     group: 'com.fasterxml.jackson.core', name: 'jackson-databind',             version: '2.7.3'
 
 }
 

--- a/src/main/java/com/capgemini/camel/bean/exceptionhandler/HttpResponseExceptionHandler.java
+++ b/src/main/java/com/capgemini/camel/bean/exceptionhandler/HttpResponseExceptionHandler.java
@@ -1,37 +1,59 @@
 package com.capgemini.camel.bean.exceptionhandler;
 
+import com.capgemini.camel.constants.ErrorType;
+import com.capgemini.camel.response.model.RestClientErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.Exchange;
 import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of an Exception Handler that returns an HTTP response with
- * error message within the response body and the appropriate HTTP status code.
+ * error response object and the appropriate HTTP status code.
  *
- * @author Abbas Attarwala
+ * @author Gayathri Thiyagarajan
  */
 public class HttpResponseExceptionHandler implements ExceptionHandler {
-    
+
+    public static final String DEFAULT_ERROR_CODE = "E0000";
+    public static final String DEFAULT_ERROR_MESSAGE = "Internal Exception Occurred";
+    private static final String EXCHANGE_ERROR_CODE = "errorCode";
     private final int BAD_REQUEST_ERROR_CODE  = HttpStatus.SC_BAD_REQUEST;
     private final int UNAUTHORIZED_ERROR_CODE = HttpStatus.SC_UNAUTHORIZED;
     private final int INTERNAL_SERVER_ERROR_CODE = HttpStatus.SC_INTERNAL_SERVER_ERROR;
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionHandler.class);
+
+    private RestClientErrorResponse errorResponse = new RestClientErrorResponse();
+    private String errorCode = DEFAULT_ERROR_CODE;
+    private String errorMessage = DEFAULT_ERROR_MESSAGE;
 
     /**
      * Should be called in the case of a Recoverable Exception that fails after all its retries.
      * Sets the Error Message in the response body with an HTTP Status header of 500 - INTERNAL SERVER ERROR
-     * 
-     * @param exchange 
+     *
+     * @param exchange
      */
     @Override
     public void handleRecoverableException(Exchange exchange) {
         Throwable cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
         String failureRouteId = exchange.getProperty(Exchange.FAILURE_ROUTE_ID, String.class);
-        String errorMessage = cause.getMessage();
+        if (exchange.getProperty(EXCHANGE_ERROR_CODE, String.class) != null) {
+            errorCode = exchange.getProperty(EXCHANGE_ERROR_CODE, String.class);
+        } else {
+            errorCode = DEFAULT_ERROR_CODE;
+        }
+        if (cause.getMessage() != null) {
+            errorMessage = cause.getMessage();
+        } else {
+            errorMessage = DEFAULT_ERROR_MESSAGE;
+        }
+        errorResponse = new RestClientErrorResponse(errorCode, errorMessage, ErrorType.FATAL.name());
         LOGGER.error("Exception occurred in the route {}. Exception details are: {}", failureRouteId, errorMessage);
-        setResponse(exchange, INTERNAL_SERVER_ERROR_CODE, errorMessage);
+        setResponse(exchange, INTERNAL_SERVER_ERROR_CODE, errorResponse);
     }
 
     /**
@@ -44,9 +66,19 @@ public class HttpResponseExceptionHandler implements ExceptionHandler {
     public void handleIrrecoverableException(Exchange exchange) {
         Throwable cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
         String failureRouteId = exchange.getProperty(Exchange.FAILURE_ROUTE_ID, String.class);
-        String errorMessage = cause.getMessage();
+        if (exchange.getProperty(EXCHANGE_ERROR_CODE, String.class) != null) {
+            errorCode = exchange.getProperty(EXCHANGE_ERROR_CODE, String.class);
+        } else {
+            errorCode = DEFAULT_ERROR_CODE;
+        }
+        if (cause.getMessage() != null) {
+            errorMessage = cause.getMessage();
+        } else {
+            errorMessage = DEFAULT_ERROR_MESSAGE;
+        }
+        errorResponse = new RestClientErrorResponse(errorCode, errorMessage, ErrorType.FATAL.name());
         LOGGER.error("Exception occurred in the route {}. Exception details are: {}", failureRouteId, errorMessage);
-        setResponse(exchange, INTERNAL_SERVER_ERROR_CODE, errorMessage);
+        setResponse(exchange, INTERNAL_SERVER_ERROR_CODE, errorResponse);
     }
     
     /**
@@ -59,9 +91,19 @@ public class HttpResponseExceptionHandler implements ExceptionHandler {
     public void handleTransformationException(Exchange exchange) {
         Throwable cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
         String failureRouteId = exchange.getProperty(Exchange.FAILURE_ROUTE_ID, String.class);
-        String errorMessage = cause.getMessage();
+        if (exchange.getProperty(EXCHANGE_ERROR_CODE, String.class) != null) {
+            errorCode = exchange.getProperty(EXCHANGE_ERROR_CODE, String.class);
+        } else {
+            errorCode = DEFAULT_ERROR_CODE;
+        }
+        if (cause.getMessage() != null) {
+            errorMessage = cause.getMessage();
+        } else {
+            errorMessage = DEFAULT_ERROR_MESSAGE;
+        }
+        errorResponse = new RestClientErrorResponse(errorCode, errorMessage, ErrorType.FATAL.name());
         LOGGER.error("Exception occured during transformation in the route {}. Exception details are: {}", failureRouteId, errorMessage);
-        setResponse(exchange, INTERNAL_SERVER_ERROR_CODE, errorMessage);
+        setResponse(exchange, INTERNAL_SERVER_ERROR_CODE, errorResponse);
     }
 
     /**
@@ -73,9 +115,19 @@ public class HttpResponseExceptionHandler implements ExceptionHandler {
     @Override
     public void handleValidationException(Exchange exchange) {
         Throwable cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
-        String errorMessage = cause.getMessage();
+        if (exchange.getProperty(EXCHANGE_ERROR_CODE, String.class) != null) {
+            errorCode = exchange.getProperty(EXCHANGE_ERROR_CODE, String.class);
+        } else {
+            errorCode = DEFAULT_ERROR_CODE;
+        }
+        if (cause.getMessage() != null) {
+            errorMessage = cause.getMessage();
+        } else {
+            errorMessage = DEFAULT_ERROR_MESSAGE;
+        }
+        errorResponse = new RestClientErrorResponse(errorCode, errorMessage, ErrorType.FATAL.name());
         LOGGER.error("A validation exception occured because : {}", errorMessage);
-        setResponse(exchange, BAD_REQUEST_ERROR_CODE, errorMessage);
+        setResponse(exchange, BAD_REQUEST_ERROR_CODE, errorResponse);
     }
 
     /**
@@ -87,22 +139,36 @@ public class HttpResponseExceptionHandler implements ExceptionHandler {
     @Override
     public void handleAuthorizationException(Exchange exchange) {
         Throwable cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
-        String errorMessage = cause.getMessage();
+        if (exchange.getProperty(EXCHANGE_ERROR_CODE, String.class) != null) {
+            errorCode = exchange.getProperty(EXCHANGE_ERROR_CODE, String.class);
+        } else {
+            errorCode = DEFAULT_ERROR_CODE;
+        }
+        if (cause.getMessage() != null) {
+            errorMessage = cause.getMessage();
+        } else {
+            errorMessage = DEFAULT_ERROR_MESSAGE;
+        }
+        errorResponse = new RestClientErrorResponse(errorCode, errorMessage, ErrorType.FATAL.name());
         LOGGER.error("An Authorization Exception  occured because : {}", errorMessage);
-        setResponse(exchange, UNAUTHORIZED_ERROR_CODE, errorMessage);
+        setResponse(exchange, UNAUTHORIZED_ERROR_CODE, errorResponse);
     }
-    
+
     /**
      * Sets the appropriate response to the exchange header and body.
-     * 
+     *
      * @param exchange
      * @param statusCode
-     * @param errorMessage 
+     * @param errorResponse
      */
-    private void setResponse(Exchange exchange, int statusCode, String errorMessage) {
+    private void setResponse(Exchange exchange, int statusCode, RestClientErrorResponse errorResponse) {
         exchange.getIn().removeHeaders("*");
         exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, statusCode);
-        exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "text/plain");
-        exchange.getIn().setBody(errorMessage);
+        exchange.getIn().setHeader(Exchange.CONTENT_TYPE, ContentType.APPLICATION_JSON);
+        try {
+            exchange.getIn().setBody(new ObjectMapper().writeValueAsString(errorResponse));
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Error parsing Error Response --> {}", e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/capgemini/camel/constants/ErrorType.java
+++ b/src/main/java/com/capgemini/camel/constants/ErrorType.java
@@ -1,0 +1,11 @@
+package com.capgemini.camel.constants;
+
+/**
+ * Enum for types of errors
+ *
+ * @author Gayathri Thiyagarajan
+ */
+public enum ErrorType {
+    FATAL,
+    WARNING
+}

--- a/src/main/java/com/capgemini/camel/response/model/RestClientErrorResponse.java
+++ b/src/main/java/com/capgemini/camel/response/model/RestClientErrorResponse.java
@@ -1,0 +1,54 @@
+package com.capgemini.camel.response.model;
+
+/**
+ * This class models an error response returned by a REST call
+ *
+ * @author Gayathri Thiyagarajan
+ */
+public class RestClientErrorResponse {
+
+    private String errorType;
+    private String code;
+    private String message;
+
+    public RestClientErrorResponse() {
+    }
+
+    public RestClientErrorResponse(String code, String message, String errorType) {
+        this.code = code;
+        this.message = message;
+        this.errorType = message;
+    }
+
+    public String getErrorType() {
+        return errorType;
+    }
+
+    public void setErrorType(String errorType) {
+        this.errorType = errorType;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override public String toString() {
+        return "RestClientErrorResponse{" +
+                "errorType=" + errorType +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
Change HttpExceptionHandler to handle a error response model so that we can return a proper JSON response in case of errors instead of a message string
NOTE: this needs change in circuit-broken-camel-rest-client to include this as a dependency as I have pulled out the ErrorResponse model in here (makes more sense)
